### PR TITLE
update-binary: support reboot_now on older recoveries

### DIFF
--- a/updater/install.c
+++ b/updater/install.c
@@ -1560,6 +1560,11 @@ Value* RebootNowFn(const char* name, State* state, int argc, Expr* argv[]) {
     property_set(ANDROID_RB_PROPERTY, buffer);
 
     sleep(5);
+    // Attempt to reboot using older methods in case the recovery
+    // that we are updating does not support init reboots
+    android_reboot(ANDROID_RB_RESTART, 0, 0);
+
+    sleep(5);
     free(property);
     ErrorAbort(state, "%s() failed to reboot", name);
     return NULL;


### PR DESCRIPTION
Attempt to reboot using older methods in case the recovery that we
are updating does not support init reboots

Ticket: CYNGNOS-1242
Change-Id: I9d6ec23c65291221e99d67b2361a2bd150319eee