### PR TITLE
Blank screen during shutdown and reboot

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -1470,6 +1470,9 @@ main(int argc, char **argv) {
 
     sync();
 
+    write_file("/sys/class/leds/lcd-backlight/brightness", "0");
+    gr_fb_blank(true);
+
     switch (after) {
         case Device::SHUTDOWN:
             ui->Print("Shutting down...\n");


### PR DESCRIPTION
Some hardware doesn't like having the panel on and still
active during pwoer cycles, so just turn it off.

Change-Id: Ied1f0802f5a2d45980ee33abf2456a291ba64beb